### PR TITLE
Revamps status/solved system

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -172,15 +172,15 @@
     <table>
     <tbody>
       {{#each rounds}}
-      <tr><th colspan=2 class="bb-status-grid-round bb-status-{{#if solved}}solved{{else if stuck this}}stuck{{else}}unsolved{{/if}}">{{name}}</th></tr>
+      <tr><th colspan=2 class="bb-status-grid-round bb-status-{{category puzzle}}">{{name}}</th></tr>
         {{#each metas}}
         <tr>
-          <td class="bb-status-grid-meta bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+          <td class="bb-status-grid-meta bb-status-{{category puzzle}}">
             <a href="#meta-anchor{{puzzle._id}}">{{puzzle.name}}</a>
           </td>
           <td class="bb-status-grid-puzzles">
             {{#each puzzles puzzle.puzzles}}
-            <div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+            <div class="bb-status-grid-cell bb-status-{{category puzzle}}">
               <a href="#puzzle-anchor{{puzzle._id}}" title="{{puzzle.name}}">{{puzzle_num}}</a>
             </div>
             {{/each}}
@@ -193,7 +193,7 @@
             <td class="bb-status-grid-meta bb-status-unsolved"><a href="#unassigned-anchor{{../_id}}">Unassigned</a></td>
             <td class="bb-status-grid-puzzles">
               {{#each puzzles this}}
-              <div class="bb-status-grid-cell bb-status-{{#if puzzle.solved}}solved{{else if stuck puzzle}}stuck{{else}}unsolved{{/if}}">
+              <div class="bb-status-grid-cell bb-status-{{category puzzle}}">
                 <a href="#puzzle-anchor{{puzzle._id}}" title="{{puzzle.name}}">{{puzzle_num}}</a>
               </div>
               {{/each}}
@@ -356,23 +356,8 @@
       {{/if}}
     </td>
     {{#unless compactMode}}
-      <td class="puzzle-status gCanEdit {{#unless puzzle.solved}}bb-editable{{/unless}}"
-          data-bbedit="tags/{{puzzle._id}}/status/value">
-        {{#if editing "tags" puzzle._id "status" "value"}}
-          <input type="text" id="tags-{{puzzle._id}}-status-value"
-                  value="{{tag "status"}}"
-                  class="input-block-level" />
-        {{else}}
-          {{#unless puzzle.solved}}
-            {{#if tag "status"}}
-              <i class="bb-delete-icon fas fa-times pull-left"
-                  title="Delete the status message for this puzzle"></i>
-            {{/if}}
-            {{tag "status"}}
-          {{else}}
-          solved!
-          {{/unless}}
-        {{/if}}
+      <td class="puzzle-status">
+        {{#statuses puzzle}}{{/statuses}}
       </td>
       {{#unless canEdit}}
         <td class="puzzle-working">
@@ -410,7 +395,7 @@
           <td style="background: {{color}}; border-top-left-radius: 100%; border-right:0;"></td>
           <td colspan="100" style="background: {{color}}; border-left:0;"></td>
       </tr>
-      <tr class="meta {{#if stuck puzzle}}bb-status-stuck{{else if puzzle.solved}}bb-status-solved{{/if}}">
+      <tr class="meta bb-status-{{category puzzle}}">
         {{> blackboard_puzzle_cells puzzle=puzzle sidebarColor=color }}
       </tr>
       {{#each puzzles}}
@@ -445,7 +430,7 @@
   
   <template name="blackboard_puzzle">
     <a name="puzzle-anchor{{puzzle._id}}" class="bb-anchor"></a>
-    <tr class="puzzle {{#if puzzle.solved}}bb-status-solved{{else if stuck puzzle}}bb-status-stuck{{/if}}" draggable="{{canEdit}}" data-puzzle-id="{{puzzle._id}}">
+    <tr class="puzzle bb-status-{{category puzzle}}" draggable="{{canEdit}}" data-puzzle-id="{{puzzle._id}}">
       {{> blackboard_puzzle_cells}}
    </tr>
   </template>

--- a/blackboard.less
+++ b/blackboard.less
@@ -157,11 +157,13 @@ body.has-emojis {
     float: right; margin-top: 4px; margin-right: 3px;
   }
   .bb-left-content, .bb-top-right-content {
-    &.bb-status-stuck { background: #ffd333; }
+    &.bb-status-stuck { background: var(--color-bg-stuck); }
+    &.bb-status-attention { background: var(--color-bg-attention); }
     &.bb-status-solved { background: var(--color-bg-solved); }
     .boring & {
       background: inherit;
-      .bb-status-stuck { background: #ffd333; }
+      .bb-status-stuck { background: var(--color-bg-stuck); }
+      .bb-status-attention { background: var(--color-bg-attention); }
       .bb-status-solved { background: var(--color-bg-solved); }
     }
     .bb-mechanics-dropdown .btn {
@@ -290,7 +292,11 @@ body.has-emojis {
       background: var(--color-bg-solved);
     }
     .bb-status-stuck {
-      background:#ffd333;
+      background: var(--color-bg-stuck);
+      color: var(--color-h1);
+    }
+    .bb-status-attention {
+      background: var(--color-bg-attention);
       color: var(--color-h1);
     }
     .bb-status-unsolved {
@@ -433,7 +439,10 @@ body.has-emojis {
     }
   }
   tr.bb-status-stuck td {
-    background-color: #ffd333;
+    background-color: var(--color-bg-stuck);
+  }
+  tr.bb-status-attention td {
+    background-color: var(--color-bg-attention);
   }
   tr.bb-status-solved td {
     padding-left: 6px;
@@ -753,6 +762,8 @@ body {
 
   /* Special backgrounds / highlighting */
   --color-bg-solved: #bcffa6;
+  --color-bg-stuck: #ffc4a6;
+  --color-bg-attention: #fff0a6;
   --color-bg-mymessage: #e8edff;
 
   /* Borders */
@@ -794,6 +805,8 @@ body.dark-theme {
 
   /* Special backgrounds / highlighting */
   --color-bg-solved: #344739;
+  --color-bg-stuck: #473434;
+  --color-bg-attention: #474734;
   --color-bg-mymessage: #0784b5;
 
   /* Borders */

--- a/client/puzzle.coffee
+++ b/client/puzzle.coffee
@@ -2,6 +2,7 @@
 
 import color from './imports/objectColor.coffee'
 import embeddable from './imports/embeddable.coffee'
+import { backsolvedStatus } from '../lib/imports/statuses.coffee'
 
 model = share.model # import
 settings = share.settings # import
@@ -97,6 +98,8 @@ Template.puzzle_info.helpers
   timerPaused: ->
     Session.get 'puzzleTimerPaused' ? false
 
+  backsolved: -> backsolvedStatus.canon in @statuses
+
 Template.puzzle_info.events
   'click .bb-reset-timer-button': (event, template) ->
     Session.set 'puzzleTimerStart', Date.now()
@@ -156,7 +159,7 @@ Template.puzzle.onCreated ->
     @subscribe 'round-for-puzzle', id
     @subscribe 'puzzles-by-meta', id
 
-# Make sure that the answer / status boxes automatically get focus when we click
+# Make sure that the answer / whiteboard boxes automatically get focus when we click
 Template.puzzle.onRendered ->
   this.autorun => 
     editing = Session.get 'editing'
@@ -256,7 +259,7 @@ okCancelEvents = share.okCancelEvents = (selector, callbacks) ->
 
 processBlackboardEdit =
   tags: (text, id, canon, field) ->
-    field = 'name' if text is null # special case for delete of status tag
+    field = 'name' if text is null # special case for delete of answer tag
     processBlackboardEdit["tags_#{field}"]?(text, id, canon)
   puzzles: (text, id, field) ->
     processBlackboardEdit["puzzles_#{field}"]?(text, id)
@@ -283,8 +286,8 @@ processBlackboardEdit =
   tags_value: (text, id, canon) ->
     n = model.Names.findOne(id)
     t = model.collection(n.type).findOne(id).tags[canon]
-    # special case for 'status' tag, which might not previously exist
-    for special in ['Status', 'Answer', 'Whiteboard']
+    # special case for 'answer' or 'whiteboard' tag, which might not previously exist
+    for special in ['Answer', 'Whiteboard']
       if (not t) and canon is model.canonical(special)
         t =
           name: special

--- a/client/sidebar.coffee
+++ b/client/sidebar.coffee
@@ -53,20 +53,6 @@ whiteboardSubmit = (content) ->
 
 # --- Puzzles for You ---
 allhands_tag = 'all hands (swarm)'
-  
-# Needed to show tags for mechanics. Copied from blackboard.coffee.
-tagHelper = ->
-  isRound = not ('feedsInto' of this)
-  tags = this?.tags or {}
-  (
-    t = tags[canon]
-    { _id: "#{@_id}/#{canon}", id: @_id, name: t.name, canon, value: t.value }
-  ) for canon in Object.keys(tags).sort() when not \
-    ((Session.equals('currentPage', 'blackboard') and \
-      (canon is 'status' or \
-          (!isRound and canon is 'answer'))) or \
-      ((canon is 'answer' or canon is 'backsolve') and \
-      (Session.equals('currentPage', 'puzzle'))))
 
 # Given a map and key, returns map[key] if it is defined and 0 otherwise.
 getDefaultZero = (map, key) ->
@@ -236,10 +222,6 @@ Template.whiteboard_textbox.onRendered ->
 
 
 # -- Puzzle-suggestion-specific template functions --
-
-# Individual puzzles in the bulletin have to know their tags.
-Template.bulletin_puzzle.helpers
-    tags: tagHelper
 
 # Manage clicks on the 'later' buttons.
 Template.bulletin_puzzle.events

--- a/client/statuses.coffee
+++ b/client/statuses.coffee
@@ -1,0 +1,18 @@
+'use strict'
+
+import {statuses, DisplayedStatus} from '../lib/imports/statuses.coffee'
+
+Template.statuses.helpers
+  displayedStatus: -> DisplayedStatus(Template.instance().data.statuses).name
+  displayedBtnType: -> DisplayedStatus(Template.instance().data.statuses).btnType
+  displayedExplanation: -> DisplayedStatus(Template.instance().data.statuses).explanation
+  statusesList: -> status for c, status of statuses
+  isChecked: -> Template.instance().data.statuses?.includes @canon
+
+Template.statuses.events
+  'change input[data-status]': (event, template) ->
+    method = if event.currentTarget.checked then 'addStatus' else 'removeStatus'
+    Meteor.call method, template.data._id, event.currentTarget.dataset.status
+  'click li a': (event, template) ->
+    # Stop the dropdown from closing.
+    event.stopPropagation()

--- a/lib/imports/statuses.coffee
+++ b/lib/imports/statuses.coffee
@@ -1,0 +1,57 @@
+'use strict'
+
+import canonical from './canonical.coffee'
+
+export statuses = {}
+
+# Statuses are:
+#   name: short name.
+#   btnType: associated button type.
+#   category: category, used for color coding (should be similar to btnType).
+#   priority: lower priorities will be shown first if there are multiple statuses set.
+#   explanation: a short explanation.
+export class Status
+  constructor: (@name, @btnType, @category, @priority, @explanation, fake=false) ->
+    @canon = canonical @name
+    unless fake
+      statuses[@canon] = @
+    Object.freeze @
+
+# Statuses should be some state that is unlikely to change unless a human takes direct action, 
+# e.g. NOT statuses that don't change over time like "new" or "has not been looked at in a while".
+# Names should also be relatively short to avoid changing table width. Current longest is 10.
+
+# Variations on 'solved':
+new Status 'Solved!', 'btn-success', 'solved', 1, 'Solved!' # Remember to change solvedStatus below if changing the name here.
+new Status 'Backsolved', 'btn-success', 'solved', 0, 'Backsolved from a meta.' # Remember to change backsolvedStatus below if changing the name here.
+new Status 'Obsolete', 'btn-success', 'solved', 2, 'This answer doesn\'t impact anything else.'
+
+# Variations on 'attention':
+new Status 'Needs eyes', 'btn-warning', 'attention', 10, 'We need a breakthrough! Please take a quick glance.'
+new Status 'Extraction', 'btn-warning', 'attention', 11, 'Information is in place but needs answer extraction.'
+
+# Variations on 'stuck':
+new Status 'Stuck', 'btn-danger', 'stuck', 21, 'We have spent lots of time and asked for in-team help without progress.'
+new Status 'Pending', 'btn-danger', 'stuck', 19, 'We\'re waiting for a response, e.g. from HQ or an on-campus teammate.'
+new Status 'Very stuck', 'btn-danger', 'stuck', 20, 'Stuck x2: We\'ve completely given up on this unless we get a hint from HQ.'
+
+Object.freeze statuses
+
+noStatus = new Status 'none', '', 'unsolved', Number.MAX_SAFE_INTEGER, 'No status set.', true
+export solvedStatus = statuses['solved!']
+export backsolvedStatus = statuses['backsolved']
+
+export IsStatus = Match.Where (x) -> statuses[x]?
+
+export DisplayedStatus = (inputStatuses) ->
+  return noStatus unless inputStatuses?
+
+  lowestPrioStatus = noStatus
+  for statusCanon in inputStatuses
+    status = statuses[statusCanon]
+    unless status?
+      console.log 'Wrong status found: ', statusCanon
+      continue
+    if status.priority < lowestPrioStatus.priority
+      lowestPrioStatus = status
+  lowestPrioStatus

--- a/puzzle.html
+++ b/puzzle.html
@@ -8,13 +8,16 @@
       {{puzzle.name}}<br>
       <button class="btn btn-inverse bb-set-link-button" title="Edit link">Set Puzzle Link</button>
     {{/if}}
+    {{> puzzle_add_tag}}
   </h5>
   {{#with puzzle}}
   {{#if solved}}
-    <b>SOLVED! Answer: {{tag "answer"}}{{#if tag "backsolved"}} (backsolved){{/if}}</b>
+    <b>SOLVED! Answer: {{tag "answer"}}{{#if backsolved}} (backsolved){{/if}}</b>
+  <!--
+     Disable this since it doesn't seem to do much anymore.
   {{else}}
-  {{> puzzle_summon_button}}
-  {{> puzzle_add_tag}}
+    {{> puzzle_summon_button}}
+  -->
   {{/if}}
   {{/with}}
 </div>
@@ -42,19 +45,8 @@
     </td></tr>
 
   <tr><td><b>Status:</b></td>
-      <td class="puzzle-status gCanEdit bb-editable edit-puzzle-field"
-        data-bbedit="tags/{{_id}}/status/value">
-      {{#if editing "tags" _id "status" "value"}}
-        <input type="text" id="tags-{{_id}}-status-value"
-                value="{{tag "status"}}"
-                class="input-block-level" />
-      {{else}}
-        {{#if tag "status"}}
-          <i class="bb-delete-icon fas fa-times pull-left"
-              title="Delete the status message for this puzzle"></i>
-        {{/if}}
-        {{tag "status"}}
-      {{/if}}
+      <td class="puzzle-status">
+        {{#statuses}}{{/statuses}}
     </td></tr>
   <tr><td><b>Mechanics:</b></td><td>{{> puzzle_mechanics}}</td></tr>
 {{/with}}
@@ -66,8 +58,7 @@
 {{/each}}
 {{#with puzzle}}
   {{#each tags}}
-    {{#if equal name "Status"}}
-    {{else if equal name "Stuckness"}}
+    {{#if equal name "Stuckness"}}
     {{else if equal name "Whiteboard"}}
     {{else}}
       <tr>
@@ -179,7 +170,7 @@
   {{else}}
   <div class="bb-vsplitter" style="{{#unless currentViewIs "info"}}padding-bottom: {{vsizePlusHandle}}px{{/unless}}">{{! start right of splitter }}
     {{#unless currentViewIs "info"}}
-    <div class="bb-top-right-content {{#if puzzle.solved}}bb-status-solved{{else if stuck}}bb-status-stuck{{/if}}">{{! start top right splitter }}
+    <div class="bb-top-right-content bb-status-{{category puzzle}}">{{! start top right splitter }}
       {{> puzzle_info }}
     </div>
     <div class="bb-splitter-handle" style="bottom: {{vsize}}px"></div>

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -20,6 +20,7 @@ puzzleQuery = (query) ->
       spreadsheet: 1
       doc: 1
       "favorites.#{@userId}": 1
+      statuses: 1
       mechanics: 1
       whiteboard: 1
       puzzles: 1

--- a/statuses.html
+++ b/statuses.html
@@ -1,0 +1,18 @@
+<template name="statuses">
+  {{! expected data context: puzzle }}
+  <div class="btn-group bb-statuses-dropdown" title="{{displayedExplanation}}">
+    <a class="btn dropdown-toggle pull-left {{displayedBtnType}} btn-small" data-toggle="dropdown" href="#">
+      {{displayedStatus}}
+      <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu">
+      {{#each statusesList}}
+      <li><a name="{{canon}}" title="{{explanation}}">
+        <label class="checkbox">
+          <input data-status="{{canon}}" type="checkbox" checked="{{isChecked}}">{{name}}
+        </label>
+      </a></li>
+      {{/each}}
+    </ul>
+  </div>
+</template>

--- a/statuses.less
+++ b/statuses.less
@@ -1,0 +1,3 @@
+.bb-statuses-dropdown {
+  text-align: left;
+}


### PR DESCRIPTION
This creates a list of possible statuses for each puzzle.

Technical details:
* This removes status as a tag on puzzles and instead makes each puzzle have a set of statuses. References to status being a tag should be removed (except in test cases).
* Dependence on "solved" for UI is now a dependence on "category", which can be "solved", "stuck", or "attention".
* There were some other minor UI changes, e.g. disabling the "Flag as STUCK" button on puzzles, for consistency's sake.

Closes #19, #51, #53, #60.